### PR TITLE
fix: re-subscribe when socket reconnects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frappe-react-sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "frappe-react-sdk",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "frappe-js-sdk": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frappe-react-sdk",
   "description": "React hooks for Frappe Framework",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "author": {
     "name": "The Commit Company",

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -930,6 +930,12 @@ export const useFrappeDocumentEventListener = (
             console.warn('Socket is not enabled. Please enable socket in FrappeProvider.')
         }
         socket?.emit('doc_subscribe', doctype, docname)
+
+        // Re-subscribe on reconnect
+        socket?.io.on("reconnect", () => {
+            socket?.emit('doc_subscribe', doctype, docname)
+        })
+
         if (emitOpenCloseEventsOnMount) {
             socket?.emit('doc_open', doctype, docname)
         }
@@ -1004,6 +1010,11 @@ export const useFrappeDocTypeEventListener = (
             console.warn('Socket is not enabled. Please enable socket in FrappeProvider.')
         }
         socket?.emit('doctype_subscribe', doctype)
+
+        // Re-subscribe on reconnect
+        socket?.io.on("reconnect", () => {
+            socket?.emit('doctype_subscribe', doctype)
+        })
         return () => {
             socket?.emit('doctype_unsubscribe', doctype)
         }


### PR DESCRIPTION
SocketIO sometimes reconnects automatically (usually on production) when either nginx cannot keep the connection alive for a long time or the server restarts.

Added a listener in our document/doctype event listeners to re-subscribe to the event (just emit again once we reconnect).