### PR TITLE
feat: allow prefetching requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "frappe-react-sdk",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "frappe-react-sdk",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "frappe-js-sdk": "^1.7.0",
         "socket.io-client": "4.7.1",
-        "swr": "^2.2.5"
+        "swr": "^2.3.0"
       },
       "devDependencies": {
         "@testing-library/dom": "^8.17.1",
@@ -1764,11 +1764,6 @@
         "node": "*"
       }
     },
-    "node_modules/client-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2019,6 +2014,14 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/doctrine": {
@@ -5152,15 +5155,15 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
-      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.0.tgz",
+      "integrity": "sha512-NyZ76wA4yElZWBHzSgEJc28a0u6QZvhb6w0azeL2k7+Q1gAzVK+IqQYXhVOC/mzi+HZIozrZvBVeSeOZNR2bqA==",
       "dependencies": {
-        "client-only": "^0.0.1",
-        "use-sync-external-store": "^1.2.0"
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
       },
       "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -5418,11 +5421,11 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -7229,11 +7232,6 @@
       "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
-    "client-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -7428,6 +7426,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -9581,12 +9584,12 @@
       "dev": true
     },
     "swr": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
-      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.0.tgz",
+      "integrity": "sha512-NyZ76wA4yElZWBHzSgEJc28a0u6QZvhb6w0azeL2k7+Q1gAzVK+IqQYXhVOC/mzi+HZIozrZvBVeSeOZNR2bqA==",
       "requires": {
-        "client-only": "^0.0.1",
-        "use-sync-external-store": "^1.2.0"
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
       }
     },
     "symbol-tree": {
@@ -9770,9 +9773,9 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "requires": {}
     },
     "v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frappe-react-sdk",
   "description": "React hooks for Frappe Framework",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "license": "MIT",
   "author": {
     "name": "The Commit Company",
@@ -91,6 +91,6 @@
   "dependencies": {
     "frappe-js-sdk": "^1.7.0",
     "socket.io-client": "4.7.1",
-    "swr": "^2.2.5"
+    "swr": "^2.3.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,21 @@
 import { useState } from 'react'
+import { useFrappeGetCall, useFrappePrefetchGetCall } from './lib'
 
 function App() {
   const [count, setCount] = useState(0)
+
+  const [mounted, setMounted] = useState(false)
+
+  const preload = useFrappePrefetchGetCall('ping')
+
+  const onClick = () => {
+    // Try prefetching here
+    preload()
+
+    setTimeout(() => {
+      setMounted(true)
+    }, 3000)
+  }
 
   return (
     <div className="App">
@@ -14,7 +28,7 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
+        <button onClick={onClick}>
           count is {count}
         </button>
         <p>
@@ -24,8 +38,17 @@ function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
+      {mounted && <FetchingComponent />}
     </div>
   )
 }
 
+
+const FetchingComponent = () => {
+
+  const {data} = useFrappeGetCall('ping')
+
+  return <div>{data?.message}</div>
+
+}
 export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
-import { useFrappeGetCall, useFrappePrefetchGetCall } from './lib'
+import { useFrappeGetCall, useFrappePrefetchCall } from './lib'
 
 function App() {
   const [count, setCount] = useState(0)
 
   const [mounted, setMounted] = useState(false)
 
-  const preload = useFrappePrefetchGetCall('ping')
+  const preload = useFrappePrefetchCall('ping')
 
   const onClick = () => {
     // Try prefetching here

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -6,7 +6,7 @@ import { FrappeFileUpload } from "frappe-js-sdk/lib/file";
 import { Error } from 'frappe-js-sdk/lib/frappe_app/types';
 import { Filter, FrappeDoc, GetDocListArgs } from 'frappe-js-sdk/lib/db/types'
 import { useCallback, useContext, useEffect, useState } from 'react'
-import useSWR, { Key, SWRConfiguration, SWRResponse, useSWRConfig, SWRConfig } from 'swr'
+import useSWR, { Key, SWRConfiguration, SWRResponse, useSWRConfig, SWRConfig, preload } from 'swr'
 import useSWRInfinite from 'swr/infinite'
 import { FileArgs } from 'frappe-js-sdk/lib/file/types';
 import { Socket } from "socket.io-client";
@@ -14,7 +14,7 @@ import { SocketIO } from "./socket";
 import { AuthCredentials, AuthResponse ,OTPCredentials,UserPassCredentials} from "frappe-js-sdk/lib/auth/types";
 
 export type { SWRConfiguration, SWRResponse, Key }
-export { useSWR, useSWRConfig, useSWRInfinite }
+export { useSWR, useSWRConfig, useSWRInfinite, preload }
 export type {OTPCredentials,UserPassCredentials,AuthCredentials,AuthResponse, FrappeDoc, GetDocListArgs, Filter, FileArgs, Error as FrappeError }
 export interface FrappeConfig {
     /** The URL of your Frappe server */
@@ -40,16 +40,23 @@ export interface TokenParams {
 export const FrappeContext = createContext<null | FrappeConfig>(null)
 
 type FrappeProviderProps = PropsWithChildren<{ 
+    /** URL of the Frappe server
+     * 
+     * Only needed if the URL of the window is not the same as the Frappe server URL */
     url?: string, 
+    /** Token parameters to be used for authentication
+     * 
+     * Only needed for token based authentication */
     tokenParams?: TokenParams, 
     /** Port on which Socket is running. Only meant for local development. Set to undefined on production. */
     socketPort?: string, 
     /** Get this from frappe.local.site on the server, or frappe.boot.sitename on the window.
-     * Required for Socket connection to work in Frappe v14+
-      */
+     * Required for Socket connection to work in Frappe v15+
+     */
     siteName?: string,
     /** Flag to disable socket, if needed. This defaults to true. */
     enableSocket?: boolean,
+    /** SWR Configuration options - these will be applied globally unless overridden */
     swrConfig?: SWRConfiguration,
     /** Custom Headers to be passed in each request */
     customHeaders?: object
@@ -200,6 +207,20 @@ export const getRequestURL = (doctype: string, url: string, docname?: string | n
  * @returns an object (SWRResponse) with the following properties: data, error, isValidating, and mutate
  * 
  * @typeParam T - The type of the document
+ * 
+ * @example
+ * 
+ * const { data, error, isLoading, mutate } = useFrappeGetDoc("User", "test")
+ * 
+ * if (isLoading) {
+ *      return <div>Loading...</div>
+ * }
+ * 
+ * if (error) {
+ *      return <div>Error: {error.message}</div>
+ * }
+ * 
+ * return <div>{data?.name} - {data?.email}</div>
  */
 export const useFrappeGetDoc = <T=any,>(doctype: string, name?: string, swrKey?: Key, options?: SWRConfiguration): SWRResponse<FrappeDoc<T>, Error> => {
 
@@ -207,9 +228,7 @@ export const useFrappeGetDoc = <T=any,>(doctype: string, name?: string, swrKey?:
 
     const swrResult = useSWR<FrappeDoc<T>, Error>(swrKey === undefined ? getRequestURL(doctype,url,name) : swrKey, () => db.getDoc<T>(doctype, name), options)
 
-    return {
-        ...swrResult
-    }
+    return swrResult
 }
 /**
  * Function that returns a query string for all arguments passed to getDocList function
@@ -272,7 +291,22 @@ export const getDocListQueryString = (args?: GetDocListArgs): string => {
  * @param options [Optional] SWRConfiguration options for fetching data
  * @returns an object (SWRResponse) with the following properties: data, error, isValidating, and mutate
  * 
-* @typeParam T - The type definition of the document object
+ * @typeParam T - The type definition of the document object
+ * 
+ * @example
+ * 
+ * const { data, error, isLoading, mutate } = useFrappeGetDocList("User")
+ * 
+ * if (isLoading) {
+ *      return <div>Loading...</div>
+ * }
+ * 
+ * if (error) {
+ *      return <div>Error: {error.message}</div>
+ * }
+ * 
+ * return <ul>{data?.map((user) => <li key={user.name}>{user.name}</li>)}</ul>
+ * 
  */
 export const useFrappeGetDocList = <T=any,K=FrappeDoc<T>>(doctype: string, args?: GetDocListArgs<K>, swrKey?: Key, options?: SWRConfiguration) => {
 
@@ -280,14 +314,47 @@ export const useFrappeGetDocList = <T=any,K=FrappeDoc<T>>(doctype: string, args?
 
     const swrResult = useSWR<T[], Error>(swrKey === undefined ? `${getRequestURL(doctype, url)}?${getDocListQueryString(args)}` : swrKey, () => db.getDocList<T, K>(doctype, args), options)
 
-    return {
-        ...swrResult
-    }
+    return swrResult
+}
+
+/**
+ * Hook to prefetch a list of documents from the database
+ * @param doctype - The doctype to fetch
+ * @param args - The arguments to pass to the getDocList method
+ * @param swrKey - The SWRKey to use for caching the result - optional
+ * @returns A function to prefetch the list of documents
+ * 
+ * @example
+ * 
+ * const preloadList = useFrappePrefetchGetDocList("User")
+ * 
+ * // Call the function when you want to prefetch the list
+ * const onHover = () => {
+ *      preloadList()
+ * }
+ */
+export const useFrappePrefetchGetDocList = (doctype: string, args?: GetDocListArgs<FrappeDoc<any>>, swrKey?: Key) => {
+    const { db, url } = useContext(FrappeContext) as FrappeConfig
+    const key = swrKey === undefined ? `${getRequestURL(doctype, url)}?${getDocListQueryString(args)}` : swrKey
+
+    const preloadCall = useCallback(() => {
+        preload(key, () => db.getDocList(doctype, args))
+    }, [key, doctype, args])
+
+    return preloadCall
 }
 
 /**
  * Hook to create a document in the database and maintain loading and error states
  * @returns Object with the following properties: loading, error, isCompleted and createDoc and reset functions
+ * 
+ * @example
+ * 
+ * const { createDoc, loading, error, isCompleted, reset } = useFrappeCreateDoc()
+ * 
+ * const onSubmit = async () => {
+ *      const doc = await createDoc("User", { name: "John Doe", email: "john.doe@example.com" })
+ * }
  */
 export const useFrappeCreateDoc = <T=any,>(): {
     /** Function to create a document in the database */
@@ -346,6 +413,14 @@ export const useFrappeCreateDoc = <T=any,>(): {
 /**
  * Hook to update a document in the database and maintain loading and error states
  * @returns Object with the following properties: loading, error, isCompleted and updateDoc and reset functions
+ * 
+ * @example
+ * 
+ * const { updateDoc, loading, error, isCompleted, reset } = useFrappeUpdateDoc()
+ * 
+ * const onSubmit = async () => {
+ *      const doc = await updateDoc("User", "test@example.com", { name: "John Doe", email: "john.doe@example.com" })
+ * }
  */
 export const useFrappeUpdateDoc = <T=any,>(): {
     /** Function to update a document in the database */
@@ -403,6 +478,14 @@ export const useFrappeUpdateDoc = <T=any,>(): {
 /**
  * Hook to delete a document in the database and maintain loading and error states
  * @returns Object with the following properties: loading, error, isCompleted and deleteDoc and reset functions
+ * 
+ * @example
+ * 
+ * const { deleteDoc, loading, error, isCompleted, reset } = useFrappeDeleteDoc()
+ * 
+ * const onDelete = async () => {
+ *      const message = await deleteDoc("User", "test@example.com")
+ * }
  */
 export const useFrappeDeleteDoc = (): {
     /** Function to delete a document in the database. Returns a promise which resolves to an object with message "ok" if successful */
@@ -476,6 +559,10 @@ function encodeQueryData(data: Record<string, any>) {
  * @param options [Optional] SWRConfiguration options for fetching data
  * @returns an object (SWRResponse) with the following properties: data (number), error, isValidating, and mutate
  * 
+ * @example
+ * 
+ * const { data, error, isLoading, mutate } = useFrappeGetDocCount("User")
+ * 
  */
 export const useFrappeGetDocCount = <T=any,>(doctype: string, filters?: Filter<T>[], cache: boolean = false, debug: boolean = false, swrKey?: Key, options?: SWRConfiguration): SWRResponse<number, Error> => {
 
@@ -487,9 +574,35 @@ export const useFrappeGetDocCount = <T=any,>(doctype: string, filters?: Filter<T
     }
     const swrResult = useSWR<number, Error>(swrKey === undefined ? getUniqueURLKey() : swrKey, () => db.getCount(doctype, filters, cache, debug), options)
 
-    return {
-        ...swrResult
-    }
+    return swrResult
+}
+
+/**
+ * Hook to prefetch the number of documents from the database
+ * @param doctype - The doctype to fetch
+ * @param filters - filters to apply to the query
+ * @param cache - Whether to cache the result or not. Defaults to false
+ * @param debug - Whether to log debug messages or not. Defaults to false
+ * @param swrKey - The SWRKey to use for caching the result - optional
+ * @returns A function to prefetch the number of documents
+ * 
+ * @example
+ * 
+ * const preloadCount = useFrappePrefetchGetDocCount("User")
+ * 
+ * // Call the function when you want to prefetch the count
+ * const onHover = () => {
+ *      preloadCount()
+ * }
+ */
+
+export const useFrappePrefetchGetDocCount = (doctype: string, filters?: Filter<any>[], cache: boolean = false, debug: boolean = false, swrKey?: Key) => {
+    const { db, url } = useContext(FrappeContext) as FrappeConfig
+    const key = swrKey === undefined ? `${url}/api/method/frappe.client.get_count?${encodeQueryData({ doctype, filters: filters ?? [], cache, debug })}` : swrKey
+    const preloadCall = useCallback(() => {
+        preload(key, () => db.getCount(doctype, filters, false, false))
+    }, [key, doctype, filters])
+    return preloadCall
 }
 
 /**
@@ -499,17 +612,23 @@ export const useFrappeGetDocCount = <T=any,>(doctype: string, filters?: Filter<T
  * @param params - parameters to pass to the method
  * @param swrKey - optional SWRKey that will be used to cache the result. If not provided, the method name with the URL params will be used as the key
  * @param options [Optional] SWRConfiguration options for fetching data
+ * @param type - type of the request to make - defaults to GET
  * 
  * @typeParam T - Type of the data returned by the method
- * @returns an object (SWRResponse) with the following properties: data (number), error, isValidating, and mutate
+ * @returns an object (SWRResponse) with the following properties: data (number), error, isValidating, isLoading, and mutate
+ * 
+ * @example
+ * 
+ * const { data, error, isLoading, mutate } = useFrappeGetCall("ping")
+ * 
  */
-export const useFrappeGetCall = <T=any,>(method: string, params?: Record<string, any>, swrKey?: Key, options?: SWRConfiguration): SWRResponse<T, Error> => {
+export const useFrappeGetCall = <T=any,>(method: string, params?: Record<string, any>, swrKey?: Key, options?: SWRConfiguration, type: 'GET' | 'POST' = 'GET'): SWRResponse<T, Error> => {
 
     const { call } = useContext(FrappeContext) as FrappeConfig
     const urlParams = encodeQueryData(params ?? {})
     const url = `${method}?${urlParams}`
 
-    const swrResult = useSWR<T, Error>(swrKey === undefined ? url : swrKey, () => call.get<T>(method, params), options)
+    const swrResult = useSWR<T, Error>(swrKey === undefined ? url : swrKey, type === 'GET' ? () => call.get(method, params) : () => call.post(method, params), options)
 
     return {
         ...swrResult
@@ -517,9 +636,46 @@ export const useFrappeGetCall = <T=any,>(method: string, params?: Record<string,
 }
 
 /**
+ * Hook to prefetch a GET request to the server
+ * @param method - name of the method to call (will be dotted path e.g. "frappe.client.get_list")
+ * @param params - parameters to pass to the method
+ * @param swrKey - optional SWRKey that will be used to cache the result. If not provided, the method name with the URL params will be used as the key
+ * @param type - type of the request to make - defaults to GET
+ * @returns A function to prefetch the GET request
+ * 
+ * @example
+ * const preload = useFrappePrefetchGetCall('ping')
+ * 
+ * // Call the function when you want to prefetch the GET request
+ * const onHover = () => {
+ *      preload()
+ * }
+ */
+export const useFrappePrefetchGetCall = (method: string, params?: Record<string, any>, swrKey?: Key, type: 'GET' | 'POST' = 'GET') => {
+    const { call } = useContext(FrappeContext) as FrappeConfig
+    const urlParams = encodeQueryData(params ?? {})
+    const url = `${method}?${urlParams}`
+
+    const preloadCall = useCallback(() => {
+        preload(swrKey ?? url, type === 'GET' ? () => call.get(method, params) : () => call.post(method, params))
+    }, [url, method, params, swrKey])
+
+    return preloadCall
+}
+
+/**
  * 
  * @param method - name of the method to call (POST request) (will be dotted path e.g. "frappe.client.set_value")
  * @returns an object with the following properties: loading, error, isCompleted , result, and call and reset functions
+ * 
+ * @example
+ * 
+ * const { call, result, loading, error, isCompleted, reset } = useFrappePostCall("frappe.client.set_value")
+ * 
+ * const onSubmit = async () => {
+ *      const message = await call({ doctype: "User", docname: "test@example.com", fieldname: "full_name", value: "John Doe" })
+ * }
+ * 
  */
 export const useFrappePostCall = <T=any,>(method: string): {
     /** Function to call the method. Returns a promise which resolves to the data returned by the method */
@@ -587,6 +743,14 @@ export const useFrappePostCall = <T=any,>(method: string): {
  * 
  * @param method - name of the method to call (PUT request) (will be dotted path e.g. "frappe.client.set_value")
  * @returns an object with the following properties: loading, error, isCompleted , result, and call and reset functions
+ * 
+ * @example
+ * 
+ * const { call, result, loading, error, isCompleted, reset } = useFrappePutCall("frappe.client.set_value")
+ * 
+ * const onSubmit = async () => {
+ *      const message = await call({ doctype: "User", docname: "test@example.com", fieldname: "full_name", value: "John Doe" })
+ * }
  */
 export const useFrappePutCall = <T=any,>(method: string): {
     /** Function to call the method. Returns a promise which resolves to the data returned by the method */
@@ -654,6 +818,14 @@ export const useFrappePutCall = <T=any,>(method: string): {
  * 
  * @param method - name of the method to call (DELETE request) (will be dotted path e.g. "frappe.client.delete")
  * @returns an object with the following properties: loading, error, isCompleted , result, and call and reset functions
+ * 
+ * @example
+ * 
+ * const { call, result, loading, error, isCompleted, reset } = useFrappeDeleteCall("frappe.client.delete")
+ * 
+ * const onSubmit = async () => {
+ *      const message = await call({ doctype: "User", docname: "test@example.com" })
+ * }
  */
 export const useFrappeDeleteCall = <T=any,>(method: string): {
     /** Function to call the method. Returns a promise which resolves to the data returned by the method */
@@ -748,25 +920,35 @@ export interface FrappeFileUploadResponse {
     "doctype": "File"
 }
 
+interface UseFrappeFileUploadReturnType<T=any> {
+ /** Function to upload the file */
+ upload: (file: File, args: FileArgs<T>, apiPath?: string) => Promise<FrappeFileUploadResponse>,
+ /** Upload Progress in % - rounded off */
+ progress: number,
+ /** Will be true when the file is being uploaded  */
+ loading: boolean,
+ /** Error object returned from API call */
+ error: Error | null,
+ /** Will be true if file upload is successful. Else false */
+ isCompleted: boolean,
+ /** Function to reset the state of the hook */
+ reset: () => void
+}
+
 /**
  * Hook to upload files to the server
  * 
  * @returns an object with the following properties: loading, error, isCompleted , result, and call and reset functions
+ * 
+ * @example
+ * 
+ * const { upload, progress, loading, error, isCompleted, reset } = useFrappeFileUpload()
+ * 
+ * const onSubmit = async () => {
+ *      const message = await upload(myFile, { doctype: "User", docname: "test@example.com", fieldname: "profile_pic", is_private: 1 })
+ * }
  */
-export const useFrappeFileUpload = <T = any>(): {
-    /** Function to upload the file */
-    upload: (file: File, args: FileArgs<T>, apiPath?: string) => Promise<FrappeFileUploadResponse>,
-    /** Upload Progress in % - rounded off */
-    progress: number,
-    /** Will be true when the file is being uploaded  */
-    loading: boolean,
-    /** Error object returned from API call */
-    error: Error | null,
-    /** Will be true if file upload is successful. Else false */
-    isCompleted: boolean,
-    /** Function to reset the state of the hook */
-    reset: () => void
-} => {
+export const useFrappeFileUpload = <T=any>(): UseFrappeFileUploadReturnType<T> => {
 
     const { file } = useContext(FrappeContext) as FrappeConfig
     const [progress, setProgress] = useState(0)
@@ -822,7 +1004,7 @@ export interface SearchResult {
 }
 
 /**
- * Hook to search for documents
+ * Hook to search for documents - only works with Frappe v15+
  * 
   * @param doctype - name of the doctype (table) where we are performing our search
   * @param text - search text
@@ -830,6 +1012,11 @@ export interface SearchResult {
   * @param limit - (optional) the number of results to return. Defaults to 20
   * @param debounce - (optional) the number of milliseconds to wait before making the API call. Defaults to 250ms.
   * @returns result - array of type SearchResult with a list of suggestions based on search text
+  * 
+  * @example
+  * 
+  * const [searchText, setSearchText] = useState("")
+  * const { data, error, isLoading, mutate } = useSearch("User", searchText)
   */
 export const useSearch = (doctype: string, text: string, filters: Filter[] = [], limit: number = 20, debounce: number = 250) => {
     const debouncedText = useDebounce(text, debounce);

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -240,14 +240,14 @@ export const useFrappeGetDoc = <T=any,>(doctype: string, name?: string, swrKey?:
  * 
  * @example
  * 
- * const preloadDoc = useFrappePrefetchGetDoc("User", "test@example.com")
+ * const preloadDoc = useFrappePrefetchDoc("User", "test@example.com")
  * 
  * // Call the function when you want to prefetch the document
  * const onHover = () => {
  *      preloadDoc()
  * }
  */
-export const useFrappePrefetchGetDoc = <T=any>(doctype: string, name?: string, swrKey?: Key, options?: SWRConfiguration) => {
+export const useFrappePrefetchDoc = <T=any>(doctype: string, name?: string, swrKey?: Key, options?: SWRConfiguration) => {
     const { db, url } = useContext(FrappeContext) as FrappeConfig
     const key = swrKey === undefined ? getRequestURL(doctype, url, name) : swrKey
     const preloadCall = useCallback(() => {
@@ -351,14 +351,14 @@ export const useFrappeGetDocList = <T=any,K=FrappeDoc<T>>(doctype: string, args?
  * 
  * @example
  * 
- * const preloadList = useFrappePrefetchGetDocList("User")
+ * const preloadList = useFrappePrefetchDocList("User")
  * 
  * // Call the function when you want to prefetch the list
  * const onHover = () => {
  *      preloadList()
  * }
  */
-export const useFrappePrefetchGetDocList = <T=any,K=FrappeDoc<T>>(doctype: string, args?: GetDocListArgs<K>, swrKey?: Key) => {
+export const useFrappePrefetchDocList = <T=any,K=FrappeDoc<T>>(doctype: string, args?: GetDocListArgs<K>, swrKey?: Key) => {
     const { db, url } = useContext(FrappeContext) as FrappeConfig
     const key = swrKey === undefined ? `${getRequestURL(doctype, url)}?${getDocListQueryString(args)}` : swrKey
 
@@ -613,7 +613,7 @@ export const useFrappeGetDocCount = <T=any,>(doctype: string, filters?: Filter<T
  * 
  * @example
  * 
- * const preloadCount = useFrappePrefetchGetDocCount("User")
+ * const preloadCount = useFrappePrefetchDocCount("User")
  * 
  * // Call the function when you want to prefetch the count
  * const onHover = () => {
@@ -621,7 +621,7 @@ export const useFrappeGetDocCount = <T=any,>(doctype: string, filters?: Filter<T
  * }
  */
 
-export const useFrappePrefetchGetDocCount = <T=any>(doctype: string, filters?: Filter<T>[], cache: boolean = false, debug: boolean = false, swrKey?: Key) => {
+export const useFrappePrefetchDocCount = <T=any>(doctype: string, filters?: Filter<T>[], cache: boolean = false, debug: boolean = false, swrKey?: Key) => {
     const { db, url } = useContext(FrappeContext) as FrappeConfig
     const key = swrKey === undefined ? `${url}/api/method/frappe.client.get_count?${encodeQueryData({ doctype, filters: filters ?? [], cache, debug })}` : swrKey
     const preloadCall = useCallback(() => {
@@ -669,14 +669,14 @@ export const useFrappeGetCall = <T=any,>(method: string, params?: Record<string,
  * @returns A function to prefetch the GET request
  * 
  * @example
- * const preload = useFrappePrefetchGetCall('ping')
+ * const preload = useFrappePrefetchCall('ping')
  * 
  * // Call the function when you want to prefetch the GET request
  * const onHover = () => {
  *      preload()
  * }
  */
-export const useFrappePrefetchGetCall = <T=any>(method: string, params?: Record<string, any>, swrKey?: Key, type: 'GET' | 'POST' = 'GET') => {
+export const useFrappePrefetchCall = <T=any>(method: string, params?: Record<string, any>, swrKey?: Key, type: 'GET' | 'POST' = 'GET') => {
     const { call } = useContext(FrappeContext) as FrappeConfig
     const urlParams = encodeQueryData(params ?? {})
     const url = `${method}?${urlParams}`

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import { FrappeProvider } from './lib'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <FrappeProvider>
+    <FrappeProvider url='http://localhost:8000' enableSocket={false}>
     <App />
     </FrappeProvider>
   </React.StrictMode>


### PR DESCRIPTION
[Prefetching](https://swr.vercel.app/docs/prefetching#programmatically-prefetch) allows us to load the data in cache in advance for a better user experience.

Usage:

```ts
const preload = useFrappePrefetchCall('ping')

const onLinkHover = () => {
    // Preload the data and populate the cache
    preload()
}
```

This would be extremely helpful if we want to preload a page's data before the user navigates to it - for example - on a Raven channel.

Four hooks added:
`useFrappePrefetchCall`, `useFrappePrefetchDocCount`,  `useFrappePrefetchDocList` and `useFrappePrefetchDoc`

Also added usage docs in all existing hooks + ability to make POST calls from `useFrappeGetCall`