### PR TITLE
fix(auth): Revalidate user data on login to prevent stale state

### DIFF
--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -163,10 +163,12 @@ export const useFrappeAuth = (options?: SWRConfiguration): {
     const login = useCallback(async (credentials:AuthCredentials) => {
         return auth.loginWithUsernamePassword(credentials)
         .then((m) => {
-            getUserCookie()
+            //  THE FIX IS HERE:
+            // Manually trigger a re-fetch of the user data after login.
+            updateCurrentUser();
             return m
         })
-    }, [])
+    }, [updateCurrentUser]) // ✅And the dependency is added here
 
     const logout = useCallback(async () => {
         return auth.logout()


### PR DESCRIPTION

This PR fixes a bug in the `useFrappeAuth` hook where the `currentUser` state would remain stale (or `undefined`) after a successful user login.

What was the problem?

After a user successfully logged in using the `login` function, the underlying SWR cache for the user session was not being invalidated. This meant that even though the authentication was successful on the backend, the hook continued to return the old, pre-login state, forcing developers to manually refresh the page to see the updated user status.

How does this fix it?

This PR resolves the issue by calling `updateCurrentUser()` (the `mutate` function returned by `useSWR`) immediately after the login promise resolves successfully.

This action tells SWR to revalidate the data for the user session key, triggering a fresh API call to `frappe.auth.get_logged_user`. The hook now correctly updates with the new user's data, ensuring the UI reflects the logged-in state instantly.

I have also added `updateCurrentUser` to the `useCallback` dependency array for the `login` function to adhere to React hooks best practices.

 How to Test

1.  Set up the example application and connect it to a local Frappe instance.
2.  Create a simple login form in `App.tsx` using the `useFrappeAuth` hook.
3.  Display the `currentUser` value on the screen (e.g., `currentUser ?? 'Not Logged In'`).
4.  Fill in the credentials and click the login button.
5.  Observe that the displayed user name immediately updates upon successful login without a page refresh.**

